### PR TITLE
New feature: use a file of power plant locations as a downscaling proxy for electricity water demand

### DIFF
--- a/src/gcam/modules.py
+++ b/src/gcam/modules.py
@@ -1002,7 +1002,7 @@ class WaterDisaggregationModule(GcamModuleBase):
                       'outputdir':outputdir, 'scenario':scenariotag,
                       'runid':runid, 'trnflag':tflag, 'trnfile':transfer_file,
                       'rdirrS':read_irrS}
-        matlabfn = "run_disaggregation('{runoff}', '{chflow}', '{histrunoff}', '{histchflow}', '{basinqfile}', '{rgnqfile}', '{rgnconfig}', '{tempdir}', {ppflg:d}, '{ppgrid}', '{outputdir}', '{scenario}', '{runid}', {trnflag:d}, '{trnfile}', {rdirrS:d})".format(**matlabdata)
+        matlabfn = "run_disaggregation('{runoff}', '{chflow}', '{histrunoff}', '{histchflow}', '{basinqfile}', '{rgnqfile}', '{rgnconfig}', '{tempdir}', {ppflg:d}, '{ppgrid}', '{outputdir}', '{scenario}', '{runid}', {trnflag:d}, '{trnfile}', {rdirrS:d}); exit".format(**matlabdata)
         print 'current dir: %s ' % os.getcwd()
         print 'matlab fn:  %s' % matlabfn
         with open(self.params["logfile"],"w") as logdata, open("/dev/null","r") as null:


### PR DESCRIPTION
An example power plant dataset is included:  `inputs/power-plants.geojson`.  To use the new capability, add to the config file:
```
power-plant-data = ./input-data/power-plants.geojson
```
If the `power-plant-data` key is not supplied, the calculation will be run with the population proxy, just as it was in previous versions.
